### PR TITLE
Add fixes for Aquila C2

### DIFF
--- a/config/printer-voxelab-aquila-H32-C2.cfg
+++ b/config/printer-voxelab-aquila-H32-C2.cfg
@@ -7,6 +7,7 @@ microsteps: 16
 rotation_distance: 40
 position_max: 220
 homing_speed: 50
+position_endstop: 0
 
 [stepper_y]
 step_pin: PB8
@@ -21,7 +22,7 @@ homing_speed: 50
 
 [stepper_z]
 step_pin: PB6
-dir_pin: PB5
+dir_pin: !PB5
 enable_pin: !PC3
 endstop_pin: ^PC4
 microsteps: 16

--- a/src/hc32f460/Kconfig
+++ b/src/hc32f460/Kconfig
@@ -33,8 +33,17 @@ config FLASH_SIZE
     hex
     default 0x40000
 
+choice
+    prompt "Flash start"
+    config HC32F460_FLASH_START_0xC000
+        bool "0xC000" 
+    config HC32F460_FLASH_START_0x8000
+        bool "0x8000" 
+endchoice
+
 config FLASH_START
     hex
+    default 0x8000 if HC32F460_FLASH_START_0x8000
     default 0xC000
 
 config RAM_SIZE


### PR DESCRIPTION
I found a solution to the problem with the board used in the C2. As I assume it uses a different processor and because of that FLASH_START needs to be changed (Use 0x8000 for C2). I added the changes to the configuration file but I am not sure about them as I had no experience with them before.  